### PR TITLE
update IO TLS fingerprint

### DIFF
--- a/examples/adafruitio_secure_esp8266/adafruitio_secure_esp8266.ino
+++ b/examples/adafruitio_secure_esp8266/adafruitio_secure_esp8266.ino
@@ -40,8 +40,9 @@ WiFiClientSecure client;
 // Setup the MQTT client class by passing in the WiFi client and MQTT server and login details.
 Adafruit_MQTT_Client mqtt(&client, AIO_SERVER, AIO_SERVERPORT, AIO_USERNAME, AIO_KEY);
 
-// io.adafruit.com SHA1 fingerprint
-const char* fingerprint = "AD 4B 64 B3 67 40 B5 FC 0E 51 9B BD 25 E9 7F 88 B6 2A A3 5B";
+// io.adafruit.com SHA1 fingerprint. Current fingerprint can be verified via: 
+//   echo | openssl s_client -connect io.adafruit.com:443 |& openssl x509 -fingerprint -noout
+#define AIO_SSL_FINGERPRINT "77 00 54 2D DA E7 D8 03 27 31 23 99 EB 27 DB CB A5 4C 57 18"
 
 /****************************** Feeds ***************************************/
 


### PR DESCRIPTION
This change updates the TLS fingerprint in the secure esp8266 example sketch to match the current cert on https://io.adafruit.com.